### PR TITLE
Implement recurring payment request option

### DIFF
--- a/src/api/paymentRequestsApi.js
+++ b/src/api/paymentRequestsApi.js
@@ -156,3 +156,13 @@ export const getStudentPaymentRequests = (lang) => {
       throw err;
     });
 };
+
+export const createRecurringPaymentRequest = (data) => {
+  return api
+    .post('/api/payment-requests/recurrence', data, { params: { lang: 'es' } })
+    .then((res) => res.data)
+    .catch((err) => {
+      console.error('Error creating recurring payment request:', err);
+      throw err;
+    });
+};


### PR DESCRIPTION
## Summary
- add API helper for new recurring payment request endpoint
- extend CreatePaymentRequestModal with schedule option
- call the recurrence endpoint when scheduling is enabled
- reset scheduling fields on form reset

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test -- -w=0` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688832aaa0388330b6947279d6164145